### PR TITLE
Archive Support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,30 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Dates are given based on Coordinated Universal Time (UTC).
 
+## [0.0.2] - 2018-10-06
+
+With the core code stable (or stable enough?), this is a push towards making things more stable and consistent.  The next step is `Archive` support, which is more or less exactly what it sounds like.
+
+No archive builder code is scheduled to be added to the core library, nor is it currently a consideration (as the methods for building archives vary too much).
+
+### Added
+- `get_child_path` to `gfs::Directory`, to allow archive loading to be done without needing to pull the stored file from underneath (though it's a bit excessive, so it's an inline) -- this is required to reduce the `ArchiveSystem` overhead without restricting it;
+- Partial resolution code for [Issue `#9`](https://github.com/ReversingSpace/cpp-gamefilesystem/issues/9):
+  - `StorageSize get_absolute_offset() const` to `storage::View` (as an inline);
+  - `StorageSize get_file_offset() const` to `storage::View` (as an inline);
+  - `StorageSize get_offset() const` (as an inline).
+- Archive support:
+  - `gfs::Archive` definition (it's an interface);
+  - `gfs::ArchiveLoaderFunc` definition (it's just a `std::function`);
+  - `gfs::ArchiveSystem` (trivial templated class for loading archives);
+  - An archive loader test.
+
+### Fixed
+- Added `GameFilesystem/Core.hpp` to `CMakeLists.txt` (it was previously missing, though it has no real effect short of being missing from IDEs);
+- Removed duplicate header include from `CMakeLists.txt` (again, no ill effects);
+- Removed old test from `Directory::create` so it actually creates on missing;
+- Bad API inclusion/removal from the previous chain of patching (now compiles after clean).
+
 ## [0.0.1-pre-alpha3-test-fix] - 2018-10-06
 
 Fix to StorageServer templating and addition of a simple test.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Dates are given based on Coordinated Universal Time (UTC).
 
+## [0.0.2-fix0] - 2018-10-07
+
+Enhancement to search path code (allowing removal).
+
+### Added
+- Adding `unregister_directory` to `ArchiveSystem`;
+- Adding `unmount` to `StorageServer`;
+- Added `std::filesystem::path get_path() const` to `gfs::FileSystem` (to enable non-pointer based testing):
+  - Added to `Directory` and `Archive` to retain compatibility (in the case of `Directory` this is just a drop of `inline` status);
+  - Added to `StorageServer` to fix its inheritance (it now returns the path of `userland`, or `""` if userland is a nullptr) -- this enables chaining of `StorageSystem` objects if required (though I still wouldn't recommend it).
+- Added `std::filesystem::path get_path() const` to `storage::File` (for consistency and to enable `Archive` work to be kept clean).
+
+### Changed
+- Updated `ArchiveSystem` and `StorageServer` tests to include removal of mounts;
+- Updated `ArchiveSystem` test's `MyArchive` implementation to reflect changes to `Archive` (from `FileSystem`).
+
 ## [0.0.2] - 2018-10-06
 
 With the core code stable (or stable enough?), this is a push towards making things more stable and consistent.  The next step is `Archive` support, which is more or less exactly what it sounds like.
@@ -14,6 +30,7 @@ No archive builder code is scheduled to be added to the core library, nor is it 
 
 ### Added
 - `get_child_path` to `gfs::Directory`, to allow archive loading to be done without needing to pull the stored file from underneath (though it's a bit excessive, so it's an inline) -- this is required to reduce the `ArchiveSystem` overhead without restricting it;
+- Added `get_path` to `gfs::Directory` (to enable equality testing);
 - Partial resolution code for [Issue `#9`](https://github.com/ReversingSpace/cpp-gamefilesystem/issues/9):
   - `StorageSize get_absolute_offset() const` to `storage::View` (as an inline);
   - `StorageSize get_file_offset() const` to `storage::View` (as an inline);

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,8 @@ set(HEADERS_ROOT
 source_group("Header Files\\ReversingSpace" FILES ${HEADERS_ROOT})
 
 set(HEADERS_GAMEFILESYSTEM
-    # Root include
-    "${PROJECT_SOURCE_DIR}/include/ReversingSpace/GameFileSystem.hpp"
+    # Core include
+    "${PROJECT_SOURCE_DIR}/include/ReversingSpace/GameFileSystem/Core.hpp"
 
     # API (common configuration/includes)
     "${PROJECT_SOURCE_DIR}/include/ReversingSpace/GameFileSystem/API.hpp"

--- a/README.md
+++ b/README.md
@@ -1,8 +1,16 @@
 # C++ Game FileSystem
 
-An easy to use, developer friendly, FileSystem library written in C++.  Due to the stabilisation of `std::filesystem`, this now uses `std::filesystem` everywhere it can, falling back to platform code only when absolutely required.
+This repository contains an easy to use, developer friendly, filesystem-like library written in modern C++.  The aim of this library is to supply indie games, tools, mods, and other applications with a mountable, flexible, and relatively performant (and relatively non-restrictive) filesystem.
 
-This was originally designed as a game virtual filesystem, and has since evolved to underpin such a thing by using memory mapping.  The core `filesystem` component is yet to be finalised and layered.
+By design, this library does not ship with any non-standard dependencies.  This means you can build it without needing to worry about weird upstream licenses, or other issues.  This just uses `std` code (including the STL), and platform specific calls (i.e. POSIX and Windows APIs at this time).
+
+This was originally designed as a game virtual filesystem, and has since evolved to underpin such a thing by using memory mapping.  The core support stems from two parts:
+
+ 1. Memory mapping (`storage::File`) is used for the base files (and supplied in a way which allows for custom `gfs::Archive` creation -- see the `archivesystem` test for a very basic example);
+ 2. A FileSystem interface (`gfs::FileSystem`) for mounting types.  In this library this is:
+   * `Directory` (a layered/wrapped directory) for standard 'on disk' work;
+   * `Archive` (`gfs::Archive`) for non-standard collections (or standard ones, this library doesn't ship any dependencies);
+   * `StorageServer` (which is, in itself, a FileSystem, so you can chain them if you really want -- useful for in-game tooling).
 
 **Until version 0.1.0 the API for this library will be up the in air.  We are trying to nail down something useful, but not overly stressful to implement.**
 
@@ -16,8 +24,6 @@ Apache 2.0 or MIT (your choice); see `COPYRIGHT` for full statement.
 
 ## Platform Support
 
-As the wiki suggests, there is limited support.  The first target is Windows (as it has the most irritating filesystem code), but what follows should explain a few things.
-
 **gcc 8 or better is required for `std::filesystem`.**
 
 ### Windows
@@ -28,12 +34,14 @@ This code likely operates fine on these platforms, but testing becomes more diff
 
 ### macOS
 
-Support for Darwin/macOS (formerly Mac OS X) comes from POSIX support and `std::filesystem`.  It should be functional, but will require someone with an updated Mac to test it further.
+macOS should work if gcc 8 (or newer) is used.  `std::filesystem` and `std::shared_mutex` are the potential blockers here.
+
+Confirming support would require someone with a modern Mac to test it.
 
 ### Linux
 
-Linux support should come from mmap as the original test code comes from there.
+Linux support has been tested fairly heavily on ARM.  Since these are API calls, it should be fine on other architectures too.
 
-### OpenBSD
+### POSIX
 
-OpenBSD is currently untested, but documentation suggests it should be fine (provided you `pledge` appropriately).
+Other POSIX systems (like OpenBSD) should be functional provided correct initialisation measures are taken (so on OpenBSD this is the right `pledge` call).

--- a/Tests.cmake
+++ b/Tests.cmake
@@ -85,3 +85,29 @@ rs_gfs_test(
     ${REVERSINGSPACE_STORAGESERVER_TEST_SOURCES}
     "" # No libs
 )
+
+# ---------------------------------------------------------------------
+# ArchiveSystem Testing
+# ---------------------------------------------------------------------
+
+set(REVERSINGSPACE_ARCHIVESYSTEM_TEST_SOURCES
+    "${PROJECT_SOURCE_DIR}/tests/archivesystem/main.cpp"
+)
+
+set(REVERSINGSPACE_ARCHIVESYSTEM_TEST_INCLUDE_DIRS 
+    "${PROJECT_SOURCE_DIR}/tests/archivesystem/"
+)
+
+option(
+    REVERSINGSPACE_ARCHIVESYSTEM_TEST
+    "Simple test for the ArchiveSystem"
+    OFF
+)
+
+rs_gfs_test(
+    REVERSINGSPACE_ARCHIVESYSTEM_TEST
+    "revspace-storage-test-archivesystem"
+    ${REVERSINGSPACE_ARCHIVESYSTEM_TEST_INCLUDE_DIRS}
+    ${REVERSINGSPACE_ARCHIVESYSTEM_TEST_SOURCES}
+    "" # No libs
+)

--- a/include/ReversingSpace/GameFileSystem/Archive.hpp
+++ b/include/ReversingSpace/GameFileSystem/Archive.hpp
@@ -62,6 +62,17 @@ namespace reversingspace {
 			virtual std::uint32_t get_child_count() const = 0;
 
 		public: // FileSystem
+
+			/**
+			 * @brief Gets the path to the Archive itself.
+			 *
+			 * Should the archive be nested within another archive the system
+			 * using it should find a way to reflect it.  This path it not
+			 * tested for validity within this library, so it may be abused
+			 * as needed.
+			 */
+			virtual std::filesystem::path get_path() const = 0;
+
 			/**
 			 * @brief Gets a file from the underlying filesystem.
 			 * @param[in] identity  Hashed identity of the file.
@@ -140,6 +151,28 @@ namespace reversingspace {
 					}
 				}
 				directories.push_back(directory);
+			}
+
+			/**
+			 * @brief Unregisters/removes a Directory from the look-up path.
+			 * @param[in] dir  Shared pointer to a directory.
+			 */
+			void unregister_directory(DirectoryPointer<FileType> directory) {
+				auto path = directory->get_path();
+				unregister_directory(path);
+			}
+
+			/**
+			 * @brief Unregisters/removes a Directory from the look-up path.
+			 * @param[in] path   Filesystem path of directory.
+			 */
+			void unregister_directory(const std::filesystem::path& path) {
+				for (auto dir = directories.begin(); dir != directories.end(); ++dir) {
+					if ((*dir)->get_path() == path) {
+						directories.erase(dir);
+						return;
+					}
+				}
 			}
 
 			/**

--- a/include/ReversingSpace/GameFileSystem/Archive.hpp
+++ b/include/ReversingSpace/GameFileSystem/Archive.hpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2017-2018 ReversingSpace. See the COPYRIGHT file at the
+ * top-level directory of this distribution and in the repository:
+ * https://github.com/ReversingSpace/cpp-gamefilesystem
+ *
+ * Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+ * http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+ * <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+ * option. This file may not be copied, modified, or distributed
+ * except according to those terms.
+**/
+
+#ifndef REVERSINGSPACE_GAMEFILESYSTEM_ARCHIVE_HPP
+#define REVERSINGSPACE_GAMEFILESYSTEM_ARCHIVE_HPP
+
+#include <ReversingSpace/GameFileSystem/Directory.hpp>
+#include <ReversingSpace/GameFileSystem/FileSystem.hpp>
+#include <ReversingSpace/Storage/Core.hpp>
+#include <ReversingSpace/Storage/File.hpp>
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace reversingspace {
+	namespace gfs {
+		/**
+		 * @brief Archive Interface (FileSystem Implementatoin)
+		 *
+		 * An archive is designed to be a simple collection of data.
+		 * It may be represented by one or more files (typically one or two),
+		 * and must contains a way to index the data within it.  It implements
+		 * (or more correctly inherits) the `FileSystem` interface.
+		 *
+		 * The purpose of an archive within a game, tool, or mod's context, is
+		 * providing a collection of (typically) read-only data to the various
+		 * systems (and subsystems).  In essence, it is a fancy collection.
+		 *
+		 * An archive does not have to contain compression (though it may).
+		 * An archive may or may not be loaded via gfs (or using direct calls);
+		 * most of the concerns pertaining to mounting come from beyond the
+		 * scope of this library.
+		 *
+		 * Note: if an archive implementation is hashed-only, it may opt to
+		 * drop any incoming `StringIdentity` based requests.  While this is
+		 * probably a bad idea for many applications (particularly mods and
+		 * developer tooling), it may be useful for end-game products (should
+		 * there be a reason to try to hide how the hashing is done).
+		 */
+		class Archive : public FileSystem {
+		public: // Archive specific.
+			/// Virtual deconstructor/destructor.
+			virtual ~Archive() {}
+
+			/**
+			 * @brief Gets the number of contained file objects.
+			 * @return Number of contained objects.
+			 *
+			 * This shall return zero if it is empty, giving the system an
+			 * opportunity to drop it rather than adding it to the mounts.
+			 */
+			virtual std::uint32_t get_child_count() const = 0;
+
+		public: // FileSystem
+			/**
+			 * @brief Gets a file from the underlying filesystem.
+			 * @param[in] identity  Hashed identity of the file.
+			 * @param[in] access    Access type (defaulting to `Read` state).
+			 * @return Pointer to a file, or nullptr if look-up fails.
+			 */
+			virtual FilePointer get_file(HashedIdentity identity,
+				storage::FileAccess access = storage::FileAccess::Read) = 0;
+
+			/**
+			 * @brief Gets a file from the underlying filesystem.
+			 * @param[in] identity  Hashed identity of the file.
+			 * @param[in] access    Access type (defaulting to `Read` state).
+			 * @return Pointer to a file, or nullptr if look-up fails.
+			 */
+			virtual FilePointer get_file(StringIdentity identity,
+				storage::FileAccess access = storage::FileAccess::Read) = 0;
+		};
+
+		/**
+		 * @brief Loader of a given Archive Type.
+		 *
+		 * @param[in] file   Shared pointer to a `storage::File`.
+		 * @return           Shared pointer to archive; nullptr on failure.
+		 *
+		 * This greatly simplifies the loading of archived data, converting
+		 * the `storage::File` extracted from the `ArchiveSystem` into a
+		 * `gfs::FileSystem` implementing type (i.e `Archive`).
+		 */
+		using ArchiveLoaderFunc = std::function<ArchivePointer(const storage::FilePointer file)>;
+
+		/**
+		 * @brief System for loading/finding archives.
+		 *
+		 * Archives need to be loaded, and forcing a particular pattern
+		 * to the loading of data files limits the potential of the system.
+		 *
+		 * Much like the mount system this treats the internal directory vector
+		 * as a stack, iterating from end to beginning.
+		 */
+		template<typename ArchiveType = Archive, typename FileType = PlatformFile>
+		class ArchiveSystem {
+		private: // Directories
+			/// Directories used for look-up.
+			std::vector<DirectoryPointer<PlatformFile>> directories;
+
+			/// Loader functions.
+			std::vector<ArchiveLoaderFunc> loaders;
+
+		public: 
+			/**
+			 * @brief Constructs a default loader instance.
+			 *
+			 * This is explicitly written out to prevent confusion;
+			 * nothing significant happens here.
+			 */
+			ArchiveSystem() = default;
+
+			/**
+			 * @brief Default deconstructor (nothing to do here)
+			 */
+			~ArchiveSystem() {}
+
+			/**
+			 * @brief Registers a directory as a look-up path.
+			 * @param[in] dir  Shared pointer to a directory.
+			 */
+			void register_directory(DirectoryPointer<FileType> directory) {
+				if (directory == nullptr) {
+					return;
+				}
+				auto path = directory->get_path();
+				for (auto dir = directories.begin(); dir != directories.end(); ++dir) {
+					if ((*dir)->get_path() == path) {
+						return;
+					}
+				}
+				directories.push_back(directory);
+			}
+
+			/**
+			 * @brief Adds a loader to the system.
+			 * @param[in] loader   Loader function.
+			 */
+			void register_loader(ArchiveLoaderFunc loader) {
+				loaders.push_back(loader);
+			}
+
+			/**
+			 * @brief Attempts to load an archive.
+			 * @param[in] name   Name of an archive.
+			 * @return Shared pointer to an archive, or nullptr on failure.
+			 */
+			ArchivePointer load(const std::string& name) {
+				// Step directories (top to bottom).
+				for (auto dir = directories.rbegin(); dir != directories.rend(); ++dir) {
+					auto path = (*dir)->get_child_path(name);
+
+					// Read symlinks.
+					while (std::filesystem::is_symlink(path)) {
+						path = std::filesystem::read_symlink(path);
+					}
+
+					// Attempt a file load, this does an internal "is it valid" check.
+					auto storage_file = storage::File::create(path);
+					if (storage_file == nullptr) {
+						continue;
+					}
+
+					// Find a valid handler.
+					for (auto handler = loaders.begin(); handler != loaders.end(); ++handler) {
+						auto archive = (*handler)(storage_file);
+						if (archive != nullptr) {
+							// Success.
+							return archive;
+						}
+					}
+				}
+				// Failure to find or load.
+				return nullptr;
+			}
+		};
+	}
+}
+
+#endif//REVERSINGSPACE_GAMEFILESYSTEM_ARCHIVE_HPP

--- a/include/ReversingSpace/GameFileSystem/Core.hpp
+++ b/include/ReversingSpace/GameFileSystem/Core.hpp
@@ -37,7 +37,6 @@
 
 namespace reversingspace {
 	namespace gfs {
-
 		/// If the file is below this size it will be completely mapped
 		/// as a view (256 * KB * B -> 256MB).
 		const std::uint64_t AUTO_FULL_MAP_SIZE = 256 * 1024 * 1024;

--- a/include/ReversingSpace/GameFileSystem/Directory.hpp
+++ b/include/ReversingSpace/GameFileSystem/Directory.hpp
@@ -29,6 +29,32 @@ namespace reversingspace {
 			std::filesystem::path path;
 
 		public:
+			/**
+			 * @brief Gets a child path from the directory.
+			 * @param[in] name  Name of the child to be appended.
+			 * @return child path (unchecked).
+			 *
+			 * This method does not check for validity of the path,
+			 * this is a task left up to the user/developer.
+			 *
+			 * This is a helper/utility function for advanced use-cases
+			 * where it's preferable to use the gfs's Directory API over
+			 * direct `std::filesystem` interaction.
+			 */
+			inline std::filesystem::path get_child_path(const std::string& name) const {
+				return path / name;
+			}
+
+			/**
+			 * @brief Gets a copy of the internal path.
+			 *
+			 * This is a copy.
+			 */
+			inline std::filesystem::path get_path() const {
+				auto p = path;
+				return p;
+			}
+
 			/// Constructor.
 			Directory() {}
 
@@ -44,10 +70,6 @@ namespace reversingspace {
 			 * @return Shared pointer to a Directory.
 			 */
 			static DirectoryPointer<FileType> create(const std::filesystem::path &dirpath) {
-				if (!std::filesystem::is_directory(dirpath)) {
-					return nullptr;
-				}
-
 				std::filesystem::path dir = dirpath;
 				
 				while (std::filesystem::is_symlink(dir)) {

--- a/include/ReversingSpace/GameFileSystem/Directory.hpp
+++ b/include/ReversingSpace/GameFileSystem/Directory.hpp
@@ -50,7 +50,7 @@ namespace reversingspace {
 			 *
 			 * This is a copy.
 			 */
-			inline std::filesystem::path get_path() const {
+			std::filesystem::path get_path() const {
 				auto p = path;
 				return p;
 			}

--- a/include/ReversingSpace/GameFileSystem/FileSystem.hpp
+++ b/include/ReversingSpace/GameFileSystem/FileSystem.hpp
@@ -35,6 +35,12 @@ namespace reversingspace {
 			virtual ~FileSystem() {}
 
 		public: // Core requirements.
+
+			/**
+			 * @brief Gets the filesystem path of the filesystem.
+			 */
+			virtual std::filesystem::path get_path() const = 0;
+			 
 			/**
 			 * @brief Gets a file from the underlying filesystem.
 			 * @param[in] identity  Hashed identity of the file.

--- a/include/ReversingSpace/GameFileSystem/PlatformFile.hpp
+++ b/include/ReversingSpace/GameFileSystem/PlatformFile.hpp
@@ -79,6 +79,7 @@ namespace reversingspace {
 				auto file = std::make_shared<PlatformFile>();
 				file->stored_file = stored;
 				file->cursor = 0;
+
 				return file;
 			}
 

--- a/include/ReversingSpace/GameFileSystem/StorageServer.hpp
+++ b/include/ReversingSpace/GameFileSystem/StorageServer.hpp
@@ -55,6 +55,18 @@ namespace reversingspace {
 			HashFunction hash_function;
 
 		public:
+
+			/**
+			 * @brief Returns the userland path.
+			 */
+			std::filesystem::path get_path() const {
+				if (userland == nullptr) {
+					return std::filesystem::path("");
+				}
+				auto p = userland->get_path();
+				return p;
+			}
+
 			/**
 			 * @brief Constructs a storage server instance from a path.
 			 * @param[in] userland_path  Path to valid userland.
@@ -104,6 +116,33 @@ namespace reversingspace {
 				}
 				dataland.insert(dataland.begin() + position, mountable);
 				return true;
+			}
+
+			/**
+			 * @brief Unmounts a generic mountable.
+			 * @param[in] mountable    Shared pointer to the mountable.
+			 */
+			void unmount(FileSystemPointer mountable) {
+				auto mountable_path = mountable->get_path();
+				for (auto mount = dataland.begin(); mount != dataland.end(); ++mount) {
+					if ((*mount)->get_path() == mountable_path) {
+						dataland.erase(mount);
+						return;
+					}
+				}
+			}
+
+			/**
+			 * @brief Unmounts a generic mountable by path.
+			 * @param[in] mountable    Path to a mountable.
+			 */
+			void unmount(const std::filesystem::path& mountable_path) {
+				for (auto mount = dataland.begin(); mount != dataland.end(); ++mount) {
+					if ((*mount)->get_path() == mountable_path) {
+						dataland.erase(mount);
+						return;
+					}
+				}
 			}
 
 			/**

--- a/include/ReversingSpace/Storage/Core.hpp
+++ b/include/ReversingSpace/Storage/Core.hpp
@@ -18,6 +18,8 @@
 #ifndef REVERSINGSPACE_STORAGE_CORE_HPP
 #define REVERSINGSPACE_STORAGE_CORE_HPP
 
+#include <ReversingSpace/GameFileSystem/API.hpp>
+
 // std::uint8_t
 #include <cstdint>
 
@@ -36,22 +38,16 @@ namespace reversingspace {
 	namespace storage {
 
 		// Forward for `File`.
-		class File;
+		class REVSPACE_GAMEFILESYSTEM_API File;
 
 		/// Shared pointer type for `File`.
 		using FilePointer = std::shared_ptr<File>;
 
 		// Forward for `Object`.
-		class View;
+		class REVSPACE_GAMEFILESYSTEM_API View;
 
 		/// Shared pointer type for `Object`.
 		using ViewPointer = std::shared_ptr<View>;
-
-		// Forward for `Directory`.
-		class Directory;
-
-		/// Shared pointer type for `Directory`.
-		using DirectoryPointer = std::shared_ptr<Directory>;
 
 		/// Storage format (to keep it consistent) for offset(s).
 		using StorageOffset = std::int64_t;

--- a/include/ReversingSpace/Storage/File.hpp
+++ b/include/ReversingSpace/Storage/File.hpp
@@ -333,6 +333,11 @@ namespace reversingspace {
 
         public:
 			/**
+			 * @brief Gets the path to the file object.
+			 */
+			std::filesystem::path get_path() const;
+
+			/**
 			 * @brief Gets a view from the mapping.
 			 * @param[in] offset Offset in the file.
 			 * @param[in] length Length of the requested map.

--- a/include/ReversingSpace/Storage/File.hpp
+++ b/include/ReversingSpace/Storage/File.hpp
@@ -36,7 +36,7 @@ namespace reversingspace {
 		 * as a 'map' or a 'view'.  It is called `View` here as it is a view
 		 * into a given map.
 		 */
-		class View {
+		class REVSPACE_GAMEFILESYSTEM_API View {
 		private:
 			/**
 			 * @brief Allow `File` to create without exposing.
@@ -149,6 +149,30 @@ namespace reversingspace {
 			 */
 			inline StorageSize get_size() const {
 				return view_length;
+			}
+
+			/**
+			 * @brief Gets the absolute offset in the file.
+			 * @return Sum of cursor and file offset (absolute offset).
+			 */
+			inline StorageSize get_absolute_offset() const {
+				return cursor + file_offset;
+			}
+
+			/**
+			 * @brief Gets the file offset (how far into the file the view is).
+			 * @return File offset
+			 */
+			inline StorageSize get_file_offset() const {
+				return file_offset;
+			}
+
+			/**
+			 * @brief Gets offset (within view/cursor).
+			 * @return The internal view offset (or cursor).
+			 */
+			inline StorageSize get_offset() const {
+				return cursor;
 			}
 
 			/**
@@ -267,7 +291,7 @@ namespace reversingspace {
 		 * The constructor is not hidden, but is completely useless (by design).
 		 * Use the static `create` method to create a `File` object.
         **/ 
-        class File : public std::enable_shared_from_this<File> {
+        class REVSPACE_GAMEFILESYSTEM_API File : public std::enable_shared_from_this<File> {
 		private:
 
 			/**

--- a/source/common/Storage/File.cpp
+++ b/source/common/Storage/File.cpp
@@ -28,6 +28,11 @@ namespace reversingspace {
 			//file_handle = PLATFORM_INVALID_FILE_HANDLE;
 		}
 
+		std::filesystem::path File::get_path() const {
+			auto p = path;
+			return p;
+		}
+
 		FilePointer File::create(const std::filesystem::path& path,
 				FileAccess access) {
 

--- a/tests/archivesystem/main.cpp
+++ b/tests/archivesystem/main.cpp
@@ -1,0 +1,125 @@
+// Test for ReversingSpace/cpp-gamefilesystem.
+
+#include <ReversingSpace/GameFileSystem.hpp>
+#include <ReversingSpace/GameFileSystem/Archive.hpp>
+#include <ReversingSpace/GameFileSystem/Directory.hpp>
+#include <ReversingSpace/GameFileSystem/File.hpp>
+#include <ReversingSpace/GameFileSystem/PlatformFile.hpp>
+#include <ReversingSpace/Storage/File.hpp>
+
+#include <iostream>
+#include <stdexcept>
+
+// memcmp, memcpy
+#include <cstring>
+
+using FileType = reversingspace::gfs::PlatformFile;
+
+// Normally this wouldn't go here, but I need it for loading and building.
+const char HEADER[4] = { 0,1,2,3 };
+
+// This is re-used.
+const char JUNK[16] = { 10,11,12,13,14,15,0,1,2,3,4,5,6,7,8,9 };
+
+/// Trivial archive type.
+class MyArchive: public reversingspace::gfs::Archive {
+private:
+	/// Internal pointer.
+	reversingspace::storage::FilePointer file;
+
+	/// Number of entries.
+	std::uint32_t count;
+
+public:
+	/// Trivial constructor.
+	MyArchive(reversingspace::storage::FilePointer file, std::uint32_t entries): file(file), count(entries),
+		reversingspace::gfs::Archive() {}
+
+public: // Archive
+	std::uint32_t get_child_count() const {
+		return count;
+	}
+
+public: // FileSystem
+	reversingspace::gfs::FilePointer get_file(reversingspace::gfs::HashedIdentity identity,
+		reversingspace::storage::FileAccess access) {
+		return nullptr;
+	}
+
+	reversingspace::gfs::FilePointer get_file(reversingspace::gfs::StringIdentity identity,
+		reversingspace::storage::FileAccess access) {
+		return nullptr;
+	}
+};
+
+reversingspace::gfs::ArchivePointer my_archive_loader(reversingspace::storage::FilePointer file) {
+	auto header_view = file->get_view(0, 8);
+	if (memcmp(header_view->get_data_pointer(), HEADER, 4) != 0) {
+		return nullptr;
+	}
+
+	// Don't do this, it's bad.
+	std::uint32_t count = 0;
+	memcpy(&count, (char*)header_view->get_data_pointer() + 4, sizeof(decltype(count)));
+	
+	return std::make_shared<MyArchive>(file, count);
+}
+
+int main(int argc, char **argv) {
+	// Create a userland directory for archive testing.
+	auto userland_directory_path = std::filesystem::current_path() / "archive_test";
+	auto userland_directory = reversingspace::gfs::Directory<FileType>::create(userland_directory_path);
+
+	if (userland_directory == nullptr) {
+		std::cout << "Failed to create or find userland testing directory." << std::endl;
+		return 0;
+	}
+
+	// Make a bad archive.
+	{
+		// This is a platform file; just crash if it's bad.
+		auto archive = userland_directory->get_file("bad_archive", reversingspace::storage::FileAccess::ReadWrite);
+		archive->write((char*)JUNK, sizeof(JUNK));
+	}
+
+	// Make a good archive.
+	{
+		// This is a platform file; just crash if it's bad.
+		auto archive = userland_directory->get_file("good_archive", reversingspace::storage::FileAccess::ReadWrite);
+		
+		// Header goes first.
+		archive->write((char*)HEADER, sizeof(HEADER));
+
+		// Count is just the number of bytes we're about to write.
+		std::uint32_t count = 16;
+		archive->write((char*)&count, sizeof(decltype(count)));
+
+		// Write 16 bytes (just use junk here)
+		archive->write((char*)JUNK, sizeof(JUNK));
+	}
+
+	{
+		// Create the archive system.
+		reversingspace::gfs::ArchiveSystem<reversingspace::gfs::Archive, FileType> archive_system;
+		archive_system.register_loader(my_archive_loader);
+		archive_system.register_directory(userland_directory);
+
+		// Test bad
+		auto bad_archive = archive_system.load("bad_archive");
+		if (bad_archive != nullptr) {
+			printf("bad archive loaded (this shouldn't happen)");
+			return 1;
+		}
+
+		// Test good
+		auto good_archive = archive_system.load("good_archive");
+		if (good_archive == nullptr) {
+			printf("good archive failed to load (this shouldn't happen)");
+			return 1;
+		}
+	}
+
+	std::filesystem::remove_all(userland_directory_path);
+
+	return 0;
+}

--- a/tests/archivesystem/main.cpp
+++ b/tests/archivesystem/main.cpp
@@ -50,6 +50,10 @@ public: // FileSystem
 		reversingspace::storage::FileAccess access) {
 		return nullptr;
 	}
+
+	std::filesystem::path get_path() const {
+		return file->get_path();
+	}
 };
 
 reversingspace::gfs::ArchivePointer my_archive_loader(reversingspace::storage::FilePointer file) {
@@ -115,6 +119,33 @@ int main(int argc, char **argv) {
 		auto good_archive = archive_system.load("good_archive");
 		if (good_archive == nullptr) {
 			printf("good archive failed to load (this shouldn't happen)");
+			return 1;
+		}
+
+		archive_system.unregister_directory(userland_directory);
+
+		// Test good (should now fail)
+		good_archive = archive_system.load("good_archive");
+		if (good_archive != nullptr) {
+			printf("good archive load with empty tree?! (this shouldn't happen)");
+			return 1;
+		}
+
+		archive_system.register_directory(userland_directory);
+
+		// Test good
+		good_archive = archive_system.load("good_archive");
+		if (good_archive == nullptr) {
+			printf("good archive failed to load (this shouldn't happen)");
+			return 1;
+		}
+
+		archive_system.unregister_directory(userland_directory_path);
+
+		// Test good (should now fail)
+		good_archive = archive_system.load("good_archive");
+		if (good_archive != nullptr) {
+			printf("good archive load with empty tree?! (this shouldn't happen)");
 			return 1;
 		}
 	}


### PR DESCRIPTION
This is the second major progression to stability after various tests have completed.

This is now marked as the blocker with two outstanding changes yet to be determined:

 1. Removal of mount point from `StorageServer`;
 2. Removal of search path/directory from `ArchiveSystem`.